### PR TITLE
Add CLI interface for math utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a few simple Python utilities.
 - `subtract.py` – subtract two numbers.
 - `naked_math.py` – basic algebra functions supporting any number of arguments.
 - `pdf_generator.py` – create a PDF using the `itextpdf` package.
+- `cli.py` – command line interface for the math utilities.
 
 ## Using `naked_math.py`
 
@@ -19,4 +20,13 @@ print(subtract(10, 5, 2))    # -> 3
 print(multiply(2, 3, 4))     # -> 24
 print(div(100, 2, 5))        # -> 10.0
 print(exponential(2, 3))     # -> 8
+```
+
+## Using the CLI
+
+Run one of the supported operations from the command line:
+
+```
+python cli.py add 1 2 3        # -> 6
+python cli.py multiply 2 3 4   # -> 24
 ```

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,43 @@
+import argparse
+from naked_math import add, subtract, multiply, div, exponential
+
+
+def main(argv=None):
+    """Command line interface for math operations."""
+    parser = argparse.ArgumentParser(description="Perform basic math operations")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_add = subparsers.add_parser("add", help="Sum numbers")
+    parser_add.add_argument("numbers", nargs="+", type=float)
+
+    parser_sub = subparsers.add_parser("subtract", help="Subtract numbers from the first")
+    parser_sub.add_argument("numbers", nargs="+", type=float)
+
+    parser_mul = subparsers.add_parser("multiply", help="Multiply numbers")
+    parser_mul.add_argument("numbers", nargs="+", type=float)
+
+    parser_div = subparsers.add_parser("div", help="Divide the first number by the rest")
+    parser_div.add_argument("numbers", nargs="+", type=float)
+
+    parser_exp = subparsers.add_parser("exponential", help="Exponentiate sequentially")
+    parser_exp.add_argument("numbers", nargs="+", type=float)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "add":
+        result = add(*args.numbers)
+    elif args.command == "subtract":
+        result = subtract(*args.numbers)
+    elif args.command == "multiply":
+        result = multiply(*args.numbers)
+    elif args.command == "div":
+        result = div(*args.numbers)
+    elif args.command == "exponential":
+        result = exponential(*args.numbers)
+    else:
+        parser.error("Unknown command")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/naked_math.py
+++ b/naked_math.py
@@ -42,8 +42,5 @@ def exponential(*args):
 
 
 if __name__ == "__main__":
-    print("Add:", add(1, 2, 3))
-    print("Subtract:", subtract(10, 1, 2))
-    print("Multiply:", multiply(2, 3, 4))
-    print("Divide:", div(100, 2, 5))
-    print("Exponential:", exponential(2, 3))
+    from cli import main as cli_main
+    cli_main()


### PR DESCRIPTION
## Summary
- add `cli.py` with an argparse interface to the math functions
- wire `naked_math.py` __main__ to call the CLI
- document the CLI in the README

## Testing
- `python cli.py add 1 2 3`
- `python naked_math.py multiply 2 3 4`
- `pytest -q` *(fails: command not found)*